### PR TITLE
Remove github pages CNAME file

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-code-of-conduct.socialtables.com


### PR DESCRIPTION
We no longer are hosting a Github Pages site here
so the CNAME file is unnecessary.
